### PR TITLE
fix(treesitter): enable setting and add vimdoc

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,6 +1,4 @@
-if true then return {} end -- REMOVE THIS LINE TO ACTIVATE THIS FILE
-
--- Example customization of Treesitter
+-- Customization of Treesitter
 ---@type LazySpec
 return {
   "nvim-treesitter/nvim-treesitter",
@@ -9,7 +7,8 @@ return {
     opts.ensure_installed = require("astrocore").list_insert_unique(
       opts.ensure_installed,
       "lua",
-      "vim"
+      "vim",
+      "vimdoc"
       -- add more arguments for adding more treesitter parsers
     )
   end,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

My bet is when people clone this repo they will not just do lua development and so perhaps everyone will just go add some lang for treesitter in this file, so we do not need to setup the return blocker in the first line. These early returns tricked me several times as I moved around the configurations and made changes and things did not take effect. I guess for this common setting, we can remove it?

Also would like to add this `vimdoc` as enforced, or recommended here. Otherwise doing some random `:help abc` will print treesitter errors.

But feel free to close the PR if you think otherwise :) 

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

`:checkhealth` gives this if `vimdoc` is not installed or updated again via TSInstall, perhaps.

```
Parser/Features         H L F I J
  - c                   ✓ ✓ ✓ ✓ ✓
  - lua                 ✓ ✓ ✓ ✓ x
  - query               ✓ ✓ ✓ ✓ ✓
  - vim                 ✓ ✓ ✓ . ✓
  - vimdoc              x . . . ✓

  Legend: H[ighlight], L[ocals], F[olds], I[ndents], In[j]ections
         +) multiple parsers found, only one will be used
         x) errors found in the query, try to run :TSUpdate {lang} ~

The following errors have been detected: ~
- ERROR lua(injections): ...im/0.9.5/share/nvim/runtime/lua/vim/treesitter/query.lua:259: query: invalid structure at position 3154 for language lua
  lua(injections) is concatenated from the following files:
  | [ERROR]:"/Users/fuyangl/.local/share/nvim-astro-v4/lazy/nvim-treesitter/queries/lua/injections.scm", failed to load: ...im/0.9.5/share/nvim/runtime/lua/vim/treesitter/query.lua:259: query: invalid structure at position 3154 for language lua
- ERROR vimdoc(highlights): ...im/0.9.5/share/nvim/runtime/lua/vim/treesitter/query.lua:259: query: invalid node type at position 746 for language vimdoc
  vimdoc(highlights) is concatenated from the following files:
  | [ERROR]:"/Users/fuyangl/.local/share/nvim-astro-v4/lazy/nvim-treesitter/queries/vimdoc/highlights.scm", failed to load: ...im/0.9.5/share/nvim/runtime/lua/vim/treesitter/query.lua:259: query: invalid node type at position 746 for language vimdoc
```
