### PR TITLE
fix(none-ls): Only extend sources, don't replace

### DIFF
--- a/lua/plugins/none-ls.lua
+++ b/lua/plugins/none-ls.lua
@@ -5,18 +5,20 @@ if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
 ---@type LazySpec
 return {
   "nvimtools/none-ls.nvim",
-  opts = function(_, config)
-    -- config variable is the default configuration table for the setup function call
+  opts = function(_, opts)
+    -- opts variable is the default configuration table for the setup function call
     -- local null_ls = require "null-ls"
 
     -- Check supported formatters and linters
     -- https://github.com/nvimtools/none-ls.nvim/tree/main/lua/null-ls/builtins/formatting
     -- https://github.com/nvimtools/none-ls.nvim/tree/main/lua/null-ls/builtins/diagnostics
-    config.sources = {
+
+    -- Only insert new sources, do not replace the existing ones
+    -- (If you wish to replace, use `opts.sources = {}` instead of the `list_insert_unique` function)
+    opts.sources = require("astrocore").list_insert_unique(opts.sources, {
       -- Set a formatter
       -- null_ls.builtins.formatting.stylua,
       -- null_ls.builtins.formatting.prettier,
-    }
-    return config -- return final config table
+    })
   end,
 }


### PR DESCRIPTION
## 📑 Description

The template for null-ls plugin, where it's shown how to add sources simply sets the sources to an empty table, with example sources commented out. It should however instead use the astrocore `list_insert_unique` function that will only extend the table, so that sources added from astrocommunity or elsewhere will not get wiped.