### PR TITLE
fix: show the original error when `git clone` fails

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,10 +1,18 @@
 -- This file simply bootstraps the installation of Lazy.nvim and then calls other files for execution
 -- This file doesn't necessarily need to be touched, BE CAUTIOUS editing this file and proceed at your own risk.
 local lazypath = vim.env.LAZY or vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
+
 if not (vim.env.LAZY or (vim.uv or vim.loop).fs_stat(lazypath)) then
   -- stylua: ignore
-  vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable", lazypath })
+  local result = vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable", lazypath })
+  if vim.v.shell_error ~= 0 then
+    -- stylua: ignore
+    vim.api.nvim_echo({ { ("Error cloning lazy.nvim:\n%s\n"):format(result), "ErrorMsg" }, { "Press any key to exit...", "MoreMsg" } }, true, {})
+    vim.fn.getchar()
+    vim.cmd.quit()
+  end
 end
+
 vim.opt.rtp:prepend(lazypath)
 
 -- validate that lazy is available


### PR DESCRIPTION
Closes https://github.com/AstroNvim/docs/issues/175


## 📑 Description

This fixes the misleading behavior when `git clone` fails for any reason, but this the original error is not displayed and the script continues to the next step.

## ℹ Additional Information

I tested the change locally by installing AstroNvim from my fork, both with and without an internet connection. 
- With an internet connection, the installation is successful. 
- Without an internet connection, now we have the original `git clone` error message that can be used for debugging.

Note that I am a Python/Rust developer, not a Lua developer. Thus, the diff should be reviewed carefully by someone with a deeper Lua knowledge. 
